### PR TITLE
Remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/pg_flame.rb
+++ b/Formula/pg_flame.rb
@@ -3,7 +3,6 @@ class PgFlame < Formula
   desc "A flamegraph generator for Postgres EXPLAIN ANALYZE output."
   homepage "https://github.com/mgartner/pg_flame"
   version "1.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/mgartner/pg_flame/releases/download/v1.2/pg_flame_1.2_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
As it stands, installing the `pg_flame` formula fails and triggers the following error:

```
Error: mgartner/tap/pg_flame: wrong number of arguments (given 1, expected 0)
```

This is due to a deprecation that was made by _homebrew-core_[^1].

To fix this issue, we can take inspiration from PRs merged in other repositories[^2] and simply remove the line where `bottle :unneeded` is called.

[^1]: for reference: https://github.com/Homebrew/brew/pull/11239
[^2]: https://github.com/aws/homebrew-tap/pull/248